### PR TITLE
Syncing nvidia-driver.eclass with gentoo (support for more cards lspci output)

### DIFF
--- a/core-hw-kit/global/eclass/nvidia-driver.eclass
+++ b/core-hw-kit/global/eclass/nvidia-driver.eclass
@@ -110,7 +110,7 @@ mask_390x=">=x11-drivers/nvidia-drivers-391.0.0"
 nvidia-driver-get-card() {
 	local NVIDIA_CARD=$(
 		[ -x /usr/sbin/lspci ] && /usr/sbin/lspci -d 10de: -n \
-			| awk -F'[: ]' '/ 0300: /{print $6}'
+			| awk -F'[: ]' '/ 03[0-9][0-9]: /{print $6}'
 	)
 
 	if [ -n "${NVIDIA_CARD}" ]; then


### PR DESCRIPTION
 Changes to be committed:
	modified:   nvidia-driver.eclass
